### PR TITLE
Fixed double pipeline execution on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,10 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    types: [opened, synchronize, reopened]
 
 env:
   BuildConfiguration: Release


### PR DESCRIPTION
Close #37

Previously, the pipeline was executed twice on pull request because of wrong triggers configuration.